### PR TITLE
Submodule versions are now printed correctly when using the -v | --version flag

### DIFF
--- a/bin/copy_versions.sh
+++ b/bin/copy_versions.sh
@@ -1,4 +1,4 @@
-mkdir -p "../build/SearchSECOParser" "../build/SearchSECOSpider" "../build/crawler"
+mkdir -p "../build/SearchSECOParser" "../build/SearchSECOSpider" "../build/SearchSECOCrawler"
 
 more "../VERSION" > "../build/VERSION"
 more "../SearchSECOParser/VERSION" > "../build/SearchSECOParser/VERSION"

--- a/libSearchSECOController/print.cpp
+++ b/libSearchSECOController/print.cpp
@@ -121,15 +121,15 @@ std::string print::plural(std::string singular, int n)
 
 void print::versionFull()
 {
-	std::string mainName = "searchseco";
+	std::string mainName = "SearchSECOController";
 
 	// Get subsystem versions.
 	int systemc = 3;
 	std::string* subsystems = new std::string[systemc]
 	{
-		"parser",
-		"crawler",
-		"spider",
+		"SearchSECOCrawler",
+		"SearchSECOSpider",
+		"SearchSECOParser",
 	};
 
 	std::ifstream versionFile;
@@ -139,7 +139,7 @@ void print::versionFull()
 	versionFile.open("VERSION");
 	std::getline(versionFile, version);
 
-	print::printline(mainName + " version " + version);
+	print::printline(mainName + "\tversion " + version);
 	
 	versionFile.close();
 
@@ -151,7 +151,7 @@ void print::versionFull()
 
 		std::getline(versionFile, version);
 
-		print::printline(">> " + system + " version " + version);
+		print::printline(">> " + system + "\tversion " + version);
 		
 		versionFile.close();
 	}


### PR DESCRIPTION
The paths to the `VERSION` files were not correct after the renaming of the modules, and the `VERSION` file from the Crawler was not copied at all on UNIX.